### PR TITLE
Refactor CMakeLists for Issue #2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cmake.configureSettings": {
+      "CMAKE_TOOLCHAIN_FILE": "C:/dev/vcpkg/scripts/buildsystems/vcpkg.cmake"
+  }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,5 +5,39 @@ project(DicomNode VERSION 1.0.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+
+# Find the DCMTK package
+find_package(DCMTK CONFIG REQUIRED)
+
 # Add your source files here
 add_executable(DicomNode main.cpp)
+# add_library(foo SHARED foo.cxx)
+set_property(TARGET DicomNode PROPERTY CXX_STANDARD 17) # see this for why these lines are added. https://github.com/microsoft/vcpkg/issues/31395#issuecomment-1571881282
+target_compile_options(DicomNode PUBLIC "/Zc:__cplusplus")
+
+# Link the required DCMTK libraries to your executable
+target_link_libraries(DicomNode PRIVATE DCMTK::DCMTK)
+
+
+    # You may also need one or more of the following targets:
+    # DCMTK::cmr DCMTK::i2d DCMTK::ijg8 DCMTK::config DCMTK::ofstd
+    # DCMTK::oflog DCMTK::dcmdata DCMTK::dcmimgle DCMTK::dcmimage
+    # DCMTK::dcmjpeg DCMTK::ijg12 DCMTK::ijg16 DCMTK::dcmjpls
+    # DCMTK::dcmtkcharls DCMTK::dcmtls DCMTK::dcmnet DCMTK::dcmsr
+    # DCMTK::dcmdsig DCMTK::dcmwlm DCMTK::dcmqrdb DCMTK::dcmpstat
+    # DCMTK::dcmrt DCMTK::dcmiod DCMTK::dcmfg DCMTK::dcmseg
+    # DCMTK::dcmtract DCMTK::dcmpmap DCMTK::dcmect
+
+    if ("${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" STREQUAL "/")
+        message(WARNING "No vcpkg install dir found, DCMTK definitions are not set")
+    else()
+        target_compile_definitions(DicomNode
+            PUBLIC
+                "DCMTK_PREFIX=${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}"
+                "DCM_DICT_DEFAULT_PATH=${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/dcmtk/dicom.dic:${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/dcmtk/private.dic"
+                "DEFAULT_CONFIGURATION_DIR=${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/etc/dcmtk/"
+                "DEFAULT_SUPPORT_DATA_DIR=${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/dcmtk/"
+        )
+    endif()
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,22 @@ find_package(DCMTK CONFIG REQUIRED)
 
 # Add your source files here
 add_executable(DicomNode main.cpp)
-# add_library(foo SHARED foo.cxx)
-set_property(TARGET DicomNode PROPERTY CXX_STANDARD 17) # see this for why these lines are added. https://github.com/microsoft/vcpkg/issues/31395#issuecomment-1571881282
+
+# If I was adding a library 
+# add_library(DicomNode SHARED foo.cxx)
+
+# see this for why these lines are added. https://github.com/microsoft/vcpkg/issues/31395#issuecomment-1571881282
+set_property(TARGET DicomNode PROPERTY CXX_STANDARD 17) 
 target_compile_options(DicomNode PUBLIC "/Zc:__cplusplus")
 
 # Link the required DCMTK libraries to your executable
 target_link_libraries(DicomNode PRIVATE DCMTK::DCMTK)
+
+# Install the executable to the bin directory, but this goes to program files, which needs administrator. 
+#install(TARGETS DicomNode DESTINATION bin)
+
+# Define the installation rule for DicomNode
+install(TARGETS DicomNode RUNTIME DESTINATION "$ENV{LOCALAPPDATA}/DicomNode/bin")
 
 
     # You may also need one or more of the following targets:

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,40 @@
-#include <iostream>
+/* In C++, please develop the following functionality: a dicom header reader that can read the header of a dicom file and return a dictionary of the header information. This should be able to read the header of any dicom file and return the information in a dictionary. */
 
-int main() {
-    std::cout << "Hello, World!" << std::endl;
+#include <iostream>
+#include <dcmtk/dcmdata/dctk.h>
+
+int main(int argc, char *argv[])
+{
+
+    if (argc != 2)
+    {
+        std::cerr << "Usage: " << argv[0] << " <dicom-file>" << std::endl;
+        return 1;
+    }
+
+    DcmFileFormat fileFormat;
+    OFCondition status = fileFormat.loadFile(argv[1]);
+
+    if (status.bad())
+    {
+        std::cerr << "Error: " << status.text() << std::endl;
+        return 2;
+    }
+
+    DcmDataset *dataset = fileFormat.getDataset();
+
+    // Example: Read the patient's name
+    OFString patientName;
+    if (dataset->findAndGetOFString(DCM_PatientName, patientName).good())
+    {
+        std::cout << "Patient's Name: " << patientName << std::endl;
+    }
+    else
+    {
+        std::cerr << "Error: Cannot access Patient's Name!" << std::endl;
+    }
+
+    // You can similarly read other tags...
+
     return 0;
 }


### PR DESCRIPTION
Addresses changes proposed in Issue #2.

Summary:
- Organized `CMakeLists.txt` for improved readability.
- Updated installation path for user-specific directory to avoid admin rights.

I've built and run the project locally, and the new installation path works as expected without admin rights. Please review and test on your setup.

Please review the changes and let me know if there are any concerns or adjustments needed. 

Related to #2.
